### PR TITLE
Fix long contributor name layout issue

### DIFF
--- a/packages/typescriptlang-org/src/templates/documentation.scss
+++ b/packages/typescriptlang-org/src/templates/documentation.scss
@@ -377,6 +377,7 @@
   text-align: center;
   display: inline-block;
   position: relative;
+  overflow: hidden;
   margin-top: 12px;
   margin-right: 3px;
 


### PR DESCRIPTION
This pull request resolves an issue where excessively long contributor names disrupted the website's layout.

#### Before

##### Desktop

![image](https://github.com/pionxzh/TypeScript-Website/assets/9910706/b67be418-0a64-4aaa-8334-9d4b1336d5ea)

##### Mobile

![image](https://github.com/pionxzh/TypeScript-Website/assets/9910706/aa5e5808-eb2b-4be3-a73d-0836cc91309b)

#### After

##### Desktop

![image](https://github.com/pionxzh/TypeScript-Website/assets/9910706/2366658f-05c3-48b4-b647-e661a4bba104)

##### Mobile

![image](https://github.com/pionxzh/TypeScript-Website/assets/9910706/96aa893f-f618-49fc-b584-231c6a4fac01)
